### PR TITLE
Fixed foolsday breaking icons on some browsers.

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -5,7 +5,7 @@ html, body {
   margin: 0;
   background-color: #ffffff;
   font-size: 0.85em; }
-  html.foolsday *, body.foolsday * {
+  html.foolsday *:not(.icon), body.foolsday *:not(.icon) {
     font-family: "Comic Sans MS", cursive, sans-serif !important; }
   html section, body section {
     width: 100%;

--- a/stylesheets/scss/main.scss
+++ b/stylesheets/scss/main.scss
@@ -8,7 +8,7 @@ html, body {
   background-color: $white;
   font-size: 0.85em;
 
-  &.foolsday *{
+  &.foolsday *:not(.icon){
     font-family: "Comic Sans MS", cursive, sans-serif !important;
   }
 


### PR DESCRIPTION
On some browsers, foolsday would break the social icons at the bottom of the site. This behavior can be observed with:

``` JavaScript
$('body').addClass("foolsday");
```

Alternate fix would be setting the font family for icons with an !important tag.
