### PR TITLE
setting preventDefault stops default draggable behavior in firefox

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -144,6 +144,11 @@ $(document).ready(function() {
   function letterClicked(event, letter){
     startX = event.pageX;
     startY = event.pageY;
+
+    if (event.preventDefault) {
+	    event.preventDefault();
+    }
+
     if (!firstClick) {
       $('.drag-target-H').css('visibility', 'visible');
       $('.drag-target-A').css('visibility', 'visible');


### PR DESCRIPTION
#16 fixes the draggable behavior in firefox for the SVG image. The 'if' statement is needed in case there are issues loading the resources or the browser.

jquery preventDefault: https://api.jquery.com/event.preventdefault/
mdn preventDefault: https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault

tested on newest firefox + chrome
still needs testing on: IE, Safari, probably more versions of firefox and chrome
